### PR TITLE
Display: Denoiser DPI scale fix

### DIFF
--- a/RenderEngine.Settings.cs
+++ b/RenderEngine.Settings.cs
@@ -27,6 +27,18 @@ namespace RhinoCyclesCore
 		/// Get or set the resolution for rendering.
 		/// </summary>
 		public Size RenderDimension { get; set; }
+
+		private int _pixelSize = 1;
+
+		/// <summary>
+		/// Get or set the pixel size.
+		/// </summary>
+		public int PixelSize
+		{
+			get { return _pixelSize; }
+			set { _pixelSize = value >= 1 ? value : 1; }
+		}
+
 		public enum AdvancedSettings
 		{
 			Seed,

--- a/RenderEngine.cs
+++ b/RenderEngine.cs
@@ -317,9 +317,16 @@ namespace RhinoCyclesCore
 			return ch > 255 ? 255 : ch;
 		}
 
+		protected Size CalculateNativeRenderSize()
+		{
+			var render_window_size = RenderWindow.Size();
+			return new Size(render_window_size.Width / PixelSize, render_window_size.Height / PixelSize);
+		}
+
 		public void BlitPixelsToRenderWindowChannel()
 		{
-			var rect = new Rectangle(0, 0, RenderWindow.Size().Width/PixelSize, RenderWindow.Size().Height/PixelSize);
+			var native_render_size = CalculateNativeRenderSize();
+			var rect = new Rectangle(0, 0, native_render_size.Width, native_render_size.Height);
 			foreach (var pass in Session.Passes)
 			{
 				IntPtr pixel_buffer = IntPtr.Zero;

--- a/RenderEngine.cs
+++ b/RenderEngine.cs
@@ -319,7 +319,7 @@ namespace RhinoCyclesCore
 
 		public void BlitPixelsToRenderWindowChannel()
 		{
-			var rect = new Rectangle(0, 0, RenderWindow.Size().Width, RenderWindow.Size().Height);
+			var rect = new Rectangle(0, 0, RenderWindow.Size().Width/PixelSize, RenderWindow.Size().Height/PixelSize);
 			foreach (var pass in Session.Passes)
 			{
 				IntPtr pixel_buffer = IntPtr.Zero;

--- a/RenderEngines/ViewportRenderEngine.cs
+++ b/RenderEngines/ViewportRenderEngine.cs
@@ -127,7 +127,10 @@ namespace RhinoCyclesCore.RenderEngines
 			if(RenderWindow != null)
 			{
 				RenderWindow.SetSize(new Size(w, h));
-				RenderWindow.SetRenderOutputRect(new Rectangle(0, 0, w / PixelSize, h / PixelSize));
+
+				var native_render_size = CalculateNativeRenderSize();
+				var rect = new Rectangle(0, 0, native_render_size.Width, native_render_size.Height);
+				RenderWindow.SetRenderOutputRect(rect);
 			}
 		}
 
@@ -299,7 +302,7 @@ Please click the link below for more information.", 69));
 					Session.Scene.Integrator.NoShadows = eds.NoShadows;
 					Session.Scene.Integrator.TagForUpdate();
 
-					var size = new Size(RenderDimension.Width / PixelSize, RenderDimension.Height / PixelSize);
+					var size = CalculateNativeRenderSize();
 
 					// lets reset session
 					if (Session.Reset(size.Width, size.Height, MaxSamples, 0, 0, size.Width, size.Height) != 0)

--- a/RenderEngines/ViewportRenderEngine.cs
+++ b/RenderEngines/ViewportRenderEngine.cs
@@ -124,7 +124,11 @@ namespace RhinoCyclesCore.RenderEngines
 		/// <param name="h">Height in pixels</param>
 		public void SetRenderSize(int w, int h)
 		{
-			RenderWindow?.SetSize(new Size(w, h));
+			if(RenderWindow != null)
+			{
+				RenderWindow.SetSize(new Size(w, h));
+				RenderWindow.SetRenderOutputRect(new Rectangle(0, 0, w / PixelSize, h / PixelSize));
+			}
 		}
 
 		public class RenderStartedEventArgs : EventArgs
@@ -222,8 +226,6 @@ Please click the link below for more information.", 69));
 
 			#endregion
 
-			var pixelSize = (int)eds.DpiScale;
-
 			#region set up session parameters
 			ThreadCount = (RenderDevice.IsCpu ? eds.Threads : 0);
 			var sessionParams = new SessionParameters(client, RenderDevice)
@@ -240,7 +242,7 @@ Please click the link below for more information.", 69));
 				ProgressiveRefine = eds.UseStartResolution,
 				Progressive = true,
 				StartResolution = eds.StartResolution,
-				PixelSize = pixelSize,
+				PixelSize = 1,
 			};
 			#endregion
 
@@ -291,12 +293,13 @@ Please click the link below for more information.", 69));
 				if (this != null && _needReset)
 				{
 					_needReset = false;
-					var size = RenderDimension;
-
+					
 					HandleIntegrator(eds);
 
 					Session.Scene.Integrator.NoShadows = eds.NoShadows;
 					Session.Scene.Integrator.TagForUpdate();
+
+					var size = new Size(RenderDimension.Width / PixelSize, RenderDimension.Height / PixelSize);
 
 					// lets reset session
 					if (Session.Reset(size.Width, size.Height, MaxSamples, 0, 0, size.Width, size.Height) != 0)

--- a/Viewport/RenderedViewport.cs
+++ b/Viewport/RenderedViewport.cs
@@ -231,7 +231,11 @@ namespace RhinoCycles.Viewport
 
 			_frameAvailable = false;
 
-			renderWindow.SetSize(new Size(w, h));
+			var renderSize = new Size(w, h);
+			var pixelSize = (int)eds.DpiScale;
+
+			renderWindow.SetSize(renderSize);
+			renderWindow.SetRenderOutputRect(new Rectangle(0, 0, w / pixelSize, h / pixelSize));
 
 			_cycles = new ViewportRenderEngine(doc.RuntimeSerialNumber, PlugIn.IdFromName("RhinoCycles"), rhinoView, Dpa)
 			{
@@ -248,10 +252,9 @@ namespace RhinoCycles.Viewport
 			_cycles.Database.LinearWorkflowChanged += DatabaseLinearWorkflowChanged;
 			_cycles.UploadProgress += _cycles_UploadProgress;
 
-			var renderSize = new Size(w, h); //Rhino.Render.RenderPipeline.RenderSize(doc);
-
 			_cycles.RenderWindow = renderWindow;
 			_cycles.RenderDimension = renderSize;
+			_cycles.PixelSize = pixelSize;
 
 			_cycles.HandleDevice(eds);
 


### PR DESCRIPTION
- Adds PixelSize property to RenderEngine class.
- Force ViewportRenderEngine to always render at native resolution.
- Make sure SetRenderOutputRect is called to indicate the relevant render output rectangle when pixel size is larger than 1.

#RH-64904 Needs testing
#RH-64904 Assigned to: nathan
#RH-64904 add Worked on by: david.eranen