### PR TITLE
Bake unsupported RDK textures for Raytraced/Cycles instead of droppin…

### DIFF
--- a/Converters/ShaderConverter.cs
+++ b/Converters/ShaderConverter.cs
@@ -183,6 +183,16 @@ namespace RhinoCyclesCore.Converters
 				texture_list.Add(cycles_texture);
 				procedural = new ResampleTextureProcedural(render_texture, cycles_texture, bitmap_converter);
 			}*/
+			else
+			{
+				// Any texture we neither support as a native Cycles procedural nor can hand
+				// to Cycles as a plain image file - e.g. third-party textures like Bongo's
+				// video texture - is baked to a bitmap through the RDK texture evaluator so it
+				// renders like Rendered mode instead of black. RH-94515.
+				CyclesTextureImage cycles_texture = new CyclesTextureImage();
+				texture_list.Add(cycles_texture);
+				procedural = new BitmapTextureProcedural(render_texture, cycles_texture, bitmap_converter, docsrn, gamma, true, is_color);
+			}
 
 			if (procedural is OneColorProcedural one_color)
 			{


### PR DESCRIPTION
…g them

ShaderConverter.CreateProcedural dispatched textures via hardcoded allow-lists (native procedurals, IsBitmapTexture, ShouldSimulate) and returned null for anything else, so the texture was silently dropped and the material rendered with only its (often black) base color. Third-party textures such as Bongo's video texture hit this path and rendered black in Raytraced/rendering while Rendered mode and Legacy render showed them correctly.

Add a catch-all that bakes any otherwise-unhandled texture to a bitmap via the RDK texture evaluator (SimulatedTexture), matching Rendered mode. Worst case (simulation yields no file) is identical to the previous behavior, so there is no regression risk for other types.

Fixes RH-94515