### PR TITLE
Fix shadow catcher visibility mask so the ground plane leaves reflect…

### DIFF
--- a/Database/ChangeDatabase.cs
+++ b/Database/ChangeDatabase.cs
@@ -2123,7 +2123,11 @@ namespace RhinoCyclesCore.Database
 				cob.IsShadowCatcher = ob.IsShadowCatcher;
 				cob.IsSolid = ob.IsSolid;
 				//cob.IsBlockInstance = true;
-				var norefl = PathRay.AllVisibility & ~PathRay.Reflect;
+				// Diffuse and Glossy are the bits that gate reflection visibility, not
+				// Reflect. A reflection bounce carries Reflect *and* one of Diffuse or
+				// Glossy, and an object survives culling when it shares any bit with the
+				// ray, so clearing Reflect on its own never hides it. Cite RH-77285.
+				var norefl = PathRay.AllVisibility & ~(PathRay.Diffuse | PathRay.Glossy);
 				var vis = ob.Visible ? (ob.IsShadowCatcher ? norefl: PathRay.AllVisibility): PathRay.Hidden;
 				if (ob.CastShadow == false)
 				{


### PR DESCRIPTION
…ions (RH-77285)

A shadows-only ground plane is meant to drop out of reflections and indirect bounces, leaving only its shadows behind. The object visibility mask tried to arrange that by clearing PathRay.Reflect, which cannot work.

Reflect (1<<1) is a path-classification bit, not a reflection-visibility bit. A reflection bounce sets Reflect *and* one of Diffuse or Glossy (see cycles/src/kernel/integrator/path_state.h:148-192), and an object survives culling whenever it shares any bit with the ray:

  if ((objects[object].visibility & visibility) == 0)   // cull

So with the mask set to everything-but-Reflect, a glossy reflection ray (Reflect|Glossy) still shares the Glossy bit and the ground plane stays visible. Cycles states the convention plainly at path_state.h:237 - "For visibility, diffuse/glossy are for reflection only." Diffuse and Glossy are the bits that gate reflection visibility, so clear those two instead.

This also makes the two suppression mechanisms agree. The shadow-catcher mix in RhinoFullNxt.GetClosureSocket already swaps in a transparent BSDF for reflection and diffuse rays; previously the visibility mask claimed to do the same thing and silently did nothing.

Note this additionally removes a shadows-only ground plane from diffuse GI bounces, so it no longer bounces light onto the model. That is believed correct for "shadows only" and is what the shader graph already did, but it is a visible change beyond the reported symptom and wants confirming.

Not a complete fix for RH-77285. The reported repro also shows the ground plane's *assigned* material in reflections rather than the substituted default material, which this change does not explain; that open question is recorded on the issue. See also RH-97755, a related hole where shadow-catcher handling is skipped entirely for two-sided materials.